### PR TITLE
Fix Boost error.

### DIFF
--- a/ethercat_hardware/src/wg_eeprom.cpp
+++ b/ethercat_hardware/src/wg_eeprom.cpp
@@ -35,6 +35,8 @@
 #include "ethercat_hardware/wg_eeprom.h"
 #include "ros/ros.h"
 
+#include <boost/thread.hpp>
+
 namespace ethercat_hardware
 {
 


### PR DESCRIPTION
Error was: ‘lock_guard’ is not a member of ‘boost’

Tested on Arch Linux with Boost 1.55.
