### PR TITLE
Bug-fix: Python executables in fingertip_pressure were installed without proper permissions.

### DIFF
--- a/fingertip_pressure/CMakeLists.txt
+++ b/fingertip_pressure/CMakeLists.txt
@@ -26,6 +26,7 @@ add_rostest(test/test_marker_rectangle.xml)
 add_rostest(test/test_marker_sphere.xml)
 
 install(DIRECTORY scripts/
+   USE_SOURCE_PERMISSIONS
    DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
 install(DIRECTORY launch


### PR DESCRIPTION
As a result, `rosrun fingertip_pressure <node>` does not work and the launch-files in fingertip_pressure crash.
