### PR TITLE
removed lingering hard-coded constant

### DIFF
--- a/ethercat_hardware/src/wg06.cpp
+++ b/ethercat_hardware/src/wg06.cpp
@@ -712,7 +712,7 @@ bool WG06::unpackFT(WG06StatusWithAccelAndFT *status, WG06StatusWithAccelAndFT *
 
   unsigned new_samples = (unsigned(status->ft_sample_count_) - unsigned(last_status->ft_sample_count_)) & 0xFF;
   ft_sample_count_ += new_samples;
-  int missed_samples = std::max(int(0), int(new_samples) - 4);
+  int missed_samples = std::max(int(0), int(new_samples) - MAX_FT_SAMPLES);
   ft_missed_samples_ += missed_samples;
   unsigned usable_samples = min(new_samples, MAX_FT_SAMPLES); 
 


### PR DESCRIPTION
MAX_FT_SAMPLES is currently set to 4, so this doesn't affect the behavior.
