### PR TITLE
Make sure to include the correct boost libraries.

### DIFF
--- a/ethercat_hardware/include/ethercat_hardware/ethercat_hardware.h
+++ b/ethercat_hardware/include/ethercat_hardware/ethercat_hardware.h
@@ -35,6 +35,10 @@
 #ifndef ETHERCAT_HARDWARE_H
 #define ETHERCAT_HARDWARE_H
 
+#include <iostream>
+#include <string>
+#include <vector>
+
 #include <pr2_hardware_interface/hardware_interface.h>
 
 #include <al/ethercat_AL.h>
@@ -51,6 +55,8 @@
 #include <boost/accumulators/statistics/stats.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/mean.hpp>
+
+#include <boost/shared_ptr.hpp>
 
 #include <boost/thread/thread.hpp>
 #include <boost/thread/mutex.hpp>

--- a/ethercat_hardware/include/ethercat_hardware/motor_heating_model.h
+++ b/ethercat_hardware/include/ethercat_hardware/motor_heating_model.h
@@ -44,6 +44,7 @@
 
 #include <boost/utility.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/thread.hpp>
 #include <boost/shared_ptr.hpp>
 
 #include <vector>

--- a/ethercat_hardware/src/ethercat_hardware.cpp
+++ b/ethercat_hardware/src/ethercat_hardware.cpp
@@ -32,6 +32,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
+#include <vector>
+
 #include "ethercat_hardware/ethercat_hardware.h"
 
 #include <ethercat/ethercat_xenomai_drv.h>
@@ -42,8 +44,11 @@
 
 #include <net/if.h>
 #include <sys/ioctl.h>
+#include <boost/bind.hpp>
 #include <boost/foreach.hpp>
 #include <boost/regex.hpp>
+#include <boost/shared_ptr.hpp>
+#include <boost/thread/thread.hpp>
 
 EthercatHardwareDiagnostics::EthercatHardwareDiagnostics() :
 

--- a/ethercat_hardware/src/motor_heating_model.cpp
+++ b/ethercat_hardware/src/motor_heating_model.cpp
@@ -40,6 +40,8 @@
 #include <boost/bind.hpp>
 #include <boost/foreach.hpp>
 #include <boost/timer.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/thread.hpp>
 
 // Use XML format when saving or loading XML file
 #include <tinyxml.h>
@@ -712,7 +714,10 @@ bool MotorHeatingModel::saveTemperatureState()
   {
     int error = errno;
     char errbuf[100];
-    strerror_r(error, errbuf, sizeof(errbuf));
+    if (strerror_r(error, errbuf, sizeof(errbuf)) != 0)
+    {
+      memcpy(errbuf, "Unknown error\0", 14);
+    }
     errbuf[sizeof(errbuf)-1] = '\0';
     ROS_WARN("Problem renaming '%s' to '%s' : (%d) '%s'", 
              tmp_filename.c_str(), save_filename_.c_str(), error, errbuf);

--- a/ethercat_hardware/src/motorconf.cpp
+++ b/ethercat_hardware/src/motorconf.cpp
@@ -52,7 +52,6 @@
 #include <ethercat_hardware/wg021.h>
 #include <ethercat_hardware/wg014.h>
 
-#include <boost/crc.hpp>
 #include <boost/foreach.hpp>
 
 #include <net/if.h>

--- a/ethercat_hardware/src/wg021.cpp
+++ b/ethercat_hardware/src/wg021.cpp
@@ -44,7 +44,6 @@
 #include <dll/ethercat_device_addressed_telegram.h>
 #include <dll/ethercat_frame.h>
 
-#include <boost/crc.hpp>
 #include <boost/static_assert.hpp>
 
 #include "ethercat_hardware/wg_util.h"

--- a/ethercat_hardware/src/wg05.cpp
+++ b/ethercat_hardware/src/wg05.cpp
@@ -44,7 +44,6 @@
 #include <dll/ethercat_device_addressed_telegram.h>
 #include <dll/ethercat_frame.h>
 
-#include <boost/crc.hpp>
 #include <boost/static_assert.hpp>
 
 PLUGINLIB_EXPORT_CLASS(WG05, EthercatDevice);

--- a/ethercat_hardware/src/wg0x.cpp
+++ b/ethercat_hardware/src/wg0x.cpp
@@ -45,6 +45,7 @@
 #include <dll/ethercat_frame.h>
 
 #include <boost/crc.hpp>
+#include <boost/shared_ptr.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/make_shared.hpp>
 

--- a/ethercat_hardware/src/wg_eeprom.cpp
+++ b/ethercat_hardware/src/wg_eeprom.cpp
@@ -35,6 +35,8 @@
 #include "ethercat_hardware/wg_eeprom.h"
 #include "ros/ros.h"
 
+#include <boost/static_assert.hpp>
+#include <boost/thread/mutex.hpp>
 #include <boost/thread.hpp>
 
 namespace ethercat_hardware


### PR DESCRIPTION
This follows the principle of "include what you use", and
also should fix the problems on the build farm in http://build.ros.org/view/Mbin_uB64/job/Mbin_uB64__ethercat_hardware__ubuntu_bionic_amd64__binary/4 .  I'll be honest; I don't understand why it just started failing now, but in my testing this does seem to fix the problem.

@k-okada A review, merge, and release to Melodic would be appreciated so we can do a Melodic sync.  Thanks!