### PR TITLE
degrade error message to warning

### DIFF
--- a/ethercat_hardware/CMakeLists.txt
+++ b/ethercat_hardware/CMakeLists.txt
@@ -48,7 +48,7 @@ add_library(
   src/wg_soft_processor.cpp src/wg_util.cpp src/wg_mailbox.cpp src/wg_eeprom.cpp
   )
 add_dependencies(ethercat_hardware ${ethercat_hardware_EXPORTED_TARGETS})
-target_link_libraries(ethercat_hardware ${catkin_LIBRARIES})
+target_link_libraries(ethercat_hardware ${catkin_LIBRARIES} ${EML_LIBRARIES})
 pr2_enable_rpath(ethercat_hardware)
 
 add_executable(motorconf 

--- a/ethercat_hardware/src/wg06.cpp
+++ b/ethercat_hardware/src/wg06.cpp
@@ -1048,7 +1048,7 @@ void WG06::diagnosticsFT(diagnostic_updater::DiagnosticStatusWrapper &d, WG06Sta
 
   if (ft_sampling_rate_error_)
   {
-    d.mergeSummary(d.ERROR, "Sampling rate error");
+    d.mergeSummary(d.WARN, "Sampling rate error");
   }
 
   if (ft_disconnected_)


### PR DESCRIPTION
This constitutes an error and can be problematic when relying on a continuous signal from the sensor,
but we see this very often and it does not justify the red error on the status board.