### PR TITLE
explicitly link EML library

### DIFF
--- a/ethercat_hardware/CMakeLists.txt
+++ b/ethercat_hardware/CMakeLists.txt
@@ -48,7 +48,7 @@ add_library(
   src/wg_soft_processor.cpp src/wg_util.cpp src/wg_mailbox.cpp src/wg_eeprom.cpp
   )
 add_dependencies(ethercat_hardware ${ethercat_hardware_EXPORTED_TARGETS})
-target_link_libraries(ethercat_hardware ${catkin_LIBRARIES})
+target_link_libraries(ethercat_hardware ${catkin_LIBRARIES} ${EML_LIBRARIES})
 pr2_enable_rpath(ethercat_hardware)
 
 add_executable(motorconf 


### PR DESCRIPTION
Trying to build against a current ROS noetic system environment, the ethercat node does not start due to a missing EC_Ethernet_Frame symbol in this library. And fair enough. The symbol was unlinked. Most likely this was hidden by other linkage before.

@knorth55